### PR TITLE
CONFIG: Update NuGet dependencies and modernise ADotNet build/PR workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       prefix: "CONFIG"
     labels:
       - "dependencies"
+    ignore:
+        - dependency-name: "FluentAssertions"
+          versions: ["8.x", "9.x", "10.x", "*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
     - synchronize
     - reopened
     - closed
-    branches:
-    - main
 jobs:
   build:
     name: Build
@@ -19,11 +17,11 @@ jobs:
     - name: Enable long paths for Git
       run: git config --system core.longpaths true
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.100
+        dotnet-version: 10.0.100
     - name: Restore
       run: dotnet restore
     - name: Build
@@ -61,7 +59,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Configure Git
@@ -134,11 +132,11 @@ jobs:
     if: needs.add_tag.result == 'success'
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.100
+        dotnet-version: 10.0.100
     - name: Restore
       run: dotnet restore
     - name: Build

--- a/.github/workflows/prLinter.yml
+++ b/.github/workflows/prLinter.yml
@@ -11,11 +11,12 @@ on:
     - main
 jobs:
   label:
-    name: Add Label(s)
+    name: Label
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
     - name: Apply Label
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: >-
@@ -84,16 +85,17 @@ jobs:
           }
     permissions:
       contents: read
+      issues: write
       pull-requests: write
   requireIssueOrTask:
     name: Require Issue Or Task Association
     runs-on: ubuntu-latest
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Get PR Information
       id: get_pr_info
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: >2-
               const pr = await github.rest.pulls.get({
@@ -110,20 +112,18 @@ jobs:
               console.log(`PR Body: ${prBody}`);
     - name: Check For Associated Issues Or Tasks
       id: check_for_issues_or_tasks
-      if: ${{ steps.get_pr_info.outputs.prOwner != 'dependabot[bot]' }}
+      if: ${{ !contains(',dependabot[bot],', format(',{0},', steps.get_pr_info.outputs.prOwner)) }}
+      env:
+        PR_BODY: ${{ steps.get_pr_info.outputs.description }}
       run: >2-
-            PR_BODY="${{ steps.get_pr_info.outputs.description }}"
-            echo "::notice::Raw PR Body: $PR_BODY"
-
-            if [[ -z "$PR_BODY" ]]; then
+            if [[ -z "${PR_BODY:-}" ]]; then
               echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
               exit 1
             fi
 
-            PR_BODY=$(echo "$PR_BODY" | tr -s '\r\n' ' ' | tr '\n' ' ' | xargs)
-            echo "::notice::Normalized PR Body: $PR_BODY"
+            NORMALIZED_PR_BODY=$(printf '%s' "$PR_BODY" | tr '\r\n' '  ' | tr -s ' ')
 
-            if echo "$PR_BODY" | grep -Piq "((close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*(\[#\d+\]|\#\d+)|(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*(\[AB#\d+\]|AB#\d+))"; then
+            if printf '%s' "$NORMALIZED_PR_BODY" | grep -Piq "(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*(\[#[0-9]+\]|#[0-9]+|\[AB#[0-9]+\]|AB#[0-9]+)"; then
               echo "Valid PR description."
             else
               echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
@@ -133,3 +133,42 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+  setAuthorAsPrAssignee:
+    name: Set Author As PR Assignee
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+    - name: Set Author As PR Assignee
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: >
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            console.log('No pull request context available.');
+            return;
+          }
+
+
+          const author = pr.user.login;
+
+          if (author.endsWith('[bot]')) {
+            console.log(`Skipping bot author: ${author}`);
+            return;
+          }
+
+
+          console.log(`Assigning PR to author: ${author}`);
+
+
+          await github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            assignees: [author]
+          });
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance/ISL.Providers.ReIdentification.Abstractions.Tests.Acceptance.csproj
@@ -20,7 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/ISL.Providers.ReIdentification.Abstractions.Tests.Unit/ISL.Providers.ReIdentification.Abstractions.Tests.Unit.csproj
+++ b/ISL.Providers.ReIdentification.Abstractions.Tests.Unit/ISL.Providers.ReIdentification.Abstractions.Tests.Unit.csproj
@@ -15,7 +15,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance/ISL.Providers.ReIdentification.DemoData.Tests.Acceptance.csproj
@@ -20,7 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/ISL.Providers.ReIdentification.DemoData.Tests.Unit/ISL.Providers.ReIdentification.DemoData.Tests.Unit.csproj
+++ b/ISL.Providers.ReIdentification.DemoData.Tests.Unit/ISL.Providers.ReIdentification.DemoData.Tests.Unit.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.DemoData/ISL.Providers.ReIdentification.DemoData.csproj
+++ b/ISL.Providers.ReIdentification.DemoData/ISL.Providers.ReIdentification.DemoData.csproj
@@ -58,7 +58,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="NHSISL.CsvHelperClient" Version="1.1.0" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>

--- a/ISL.Providers.ReIdentification.Infrastructure/ISL.Providers.ReIdentification.Infrastructure.csproj
+++ b/ISL.Providers.ReIdentification.Infrastructure/ISL.Providers.ReIdentification.Infrastructure.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ADotNet" Version="4.3.0" />
+		<PackageReference Include="ADotNet" Version="5.0.0" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 	</ItemGroup>
 

--- a/ISL.Providers.ReIdentification.Infrastructure/Program.cs
+++ b/ISL.Providers.ReIdentification.Infrastructure/Program.cs
@@ -15,7 +15,7 @@ namespace ISL.Providers.ReIdentification.Infrastructure
             scriptGenerationService.GenerateBuildScript(
                 branchName: "main",
                 projectName: "ISL.Providers.ReIdentification.Abstractions",
-                dotNetVersion: "9.0.100");
+                dotNetVersion: "10.0.100");
 
             scriptGenerationService.GeneratePrLintScript("main");
         }

--- a/ISL.Providers.ReIdentification.Infrastructure/Services/ScriptGenerationService.cs
+++ b/ISL.Providers.ReIdentification.Infrastructure/Services/ScriptGenerationService.cs
@@ -7,7 +7,7 @@ using System.IO;
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV3s;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV5s;
 
 namespace ISL.Providers.ReIdentification.Infrastructure.Services
 {
@@ -30,8 +30,7 @@ namespace ISL.Providers.ReIdentification.Infrastructure.Services
 
                     PullRequest = new PullRequestEvent
                     {
-                        Types = ["opened", "synchronize", "reopened", "closed"],
-                        Branches = [branchName]
+                        Types = ["opened", "synchronize", "reopened", "closed"]
                     }
                 },
 
@@ -59,18 +58,18 @@ namespace ISL.Providers.ReIdentification.Infrastructure.Services
                                     Run = "git config --system core.longpaths true"
                                 },
 
-                                new CheckoutTaskV3
+                                new CheckoutTaskV5
                                 {
                                     Name = "Check out"
                                 },
 
-                                new SetupDotNetTaskV3
+                                new SetupDotNetTaskV5
                                 {
                                     Name = "Setup .Net",
 
-                                    With = new TargetDotNetVersionV3
+                                    With = new TargetDotNetVersionV5
                                     {
-                                        DotNetVersion = "9.0.100"
+                                        DotNetVersion = "10.0.100"
                                     }
                                 },
 
@@ -124,7 +123,7 @@ namespace ISL.Providers.ReIdentification.Infrastructure.Services
                     },
                     {
                         "add_tag",
-                        new TagJob(
+                        new TagJobV2(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "build",
                             projectRelativePath: $"{projectName}/{projectName}.csproj",
@@ -136,7 +135,7 @@ namespace ISL.Providers.ReIdentification.Infrastructure.Services
                     },
                     {
                         "publish",
-                        new PublishJobV2(
+                        new PublishJobV4(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "add_tag",
                             dotNetVersion: dotNetVersion,
@@ -180,16 +179,23 @@ namespace ISL.Providers.ReIdentification.Infrastructure.Services
                 {
                     {
                         "label",
-                        new LabelJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        new LabelJobV3(runsOn: BuildMachines.UbuntuLatest)
                         {
-                            Name = "Add Label(s)",
+                            Name = "Label"
                         }
                     },
                     {
                         "requireIssueOrTask",
-                        new RequireIssueOrTaskJob()
+                        new RequireIssueOrTaskJobV2(excludedAuthors: "dependabot[bot]")
                         {
                             Name = "Require Issue Or Task Association",
+                        }
+                    },
+                    {
+                        "setAuthorAsPrAssignee",
+                        new SetAuthorAsPrAssigneeJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        {
+                            Name = "Set Author As PR Assignee",
                         }
                     },
                 }

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -24,7 +24,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="WireMock.Net" Version="2.6.0" />
+		<PackageReference Include="WireMock.Net" Version="2.11.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Acceptance/ISL.Providers.ReIdentification.Necs.Tests.Acceptance.csproj
@@ -20,7 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -24,7 +24,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="WireMock.Net" Version="2.6.0" />
+		<PackageReference Include="WireMock.Net" Version="2.11.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="WireMock.Net" Version="2.6.0" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Integrations/ISL.Providers.ReIdentification.Necs.Tests.Integrations.csproj
@@ -20,7 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/ISL.Providers.ReIdentification.Necs.Tests.Unit/ISL.Providers.ReIdentification.Necs.Tests.Unit.csproj
+++ b/ISL.Providers.ReIdentification.Necs.Tests.Unit/ISL.Providers.ReIdentification.Necs.Tests.Unit.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.Necs/ISL.Providers.ReIdentification.Necs.csproj
+++ b/ISL.Providers.ReIdentification.Necs/ISL.Providers.ReIdentification.Necs.csproj
@@ -55,7 +55,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="RESTFulSense" Version="3.2.0" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Acceptance.csproj
@@ -20,7 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Unit/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Unit.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Unit/ISL.Providers.ReIdentification.OfflineFileSources.Tests.Unit.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ISL.Providers.ReIdentification.OfflineFileSources/ISL.Providers.ReIdentification.OfflineFileSources.csproj
+++ b/ISL.Providers.ReIdentification.OfflineFileSources/ISL.Providers.ReIdentification.OfflineFileSources.csproj
@@ -59,7 +59,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="NHSISL.CsvHelperClient" Version="1.1.0" />
 		<PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
Brings ISL.Providers.ReIdentification up to the .NET 10 modernisation standard.

closes [AB#29742](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29742)

### Dependency updates (CONFIG)
- Microsoft.Extensions.Configuration / .Json / .Binder / .EnvironmentVariables / .DependencyInjection 10.0.8 -> 10.0.9
- Microsoft.NET.Test.Sdk 18.5.1 -> 18.7.0
- WireMock.Net 2.6.0 -> 2.11.0
- ADotNet 4.3.0 -> 5.0.0

### Workflow modernisation (CODE RUB)
- ADotNet components -> latest (CheckoutTaskV5 / SetupDotNetTaskV5 / LabelJobV3 / TagJobV2 / PublishJobV4); build.yml now on Node-24 actions
- Build SDK corrected 9.0.100 -> 10.0.100 (build + publish now on .NET 10)
- prLinter.yml: added Set Author As PR Assignee; RequireIssueOrTask -> V2 (excludes dependabot[bot]); Label -> V3 (byte-identical to reference)
- Dropped the PR branch-filter from build.yml (kept on prLinter, per Christo)
- dependabot.yml: added FluentAssertions ignore rule

### Validation
- Build: 0 errors, 0 obsolete warnings
- CI-run tests pass: Abstractions, NECS, OfflineFileSources (Unit + Acceptance)
- Workflows regenerated from the Infrastructure project (idempotent, not hand-edited)

### Flags for reviewer / follow-up dev work
- **NHSISL.CsvHelperClient 1.1.0 -> 3.1.0 (major) NOT applied** - it breaks the build: `OfflineSourceBroker.cs:38 CS1503: cannot convert 'string' to 'System.IO.Stream'` (the 3.x API takes a Stream, not a path). Needs a code change in OfflineSourceBroker to adopt the new API; left at 1.1.0.
- DemoData.Tests.Acceptance.ShouldReIdentifyAsync fails locally (test-data identifier length mismatch) - **pre-existing** (fails identically on origin/main) and **not run by CI**.
- Necs Integration test fails locally (external NECS endpoint) - not run by CI.
- WireMock 2.11 reduces the pre-existing Scriban.Signed vuln High -> Moderate (test-only transitive).
